### PR TITLE
Add debug log window

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Give any ride a cohesive identity in seconds. Pick a theme, tick the parts you w
 - **Safe by design** — feature-detects capabilities; falls back gracefully if your OpenRCT2 build lacks certain setters.
 - **Optimised placement** — avoids paths and steep slopes by default, with a hard cap to prevent clutter.
 - **Ride picker** ignores shops, toilets, kiosks and other facilities that can't be themed.
+- **Debug log window** for tracking actions and troubleshooting.
 
 ---
 
@@ -68,6 +69,7 @@ You can also press **Suggest on-theme name** to copy a fresh name suggestion.
   - **Avoid paths**: prevent blocking guests
   - **Avoid steep tiles**
   - **Rotate randomly**
+- **Debug Log**: Opens a window showing recent actions for troubleshooting
 
 ---
 


### PR DESCRIPTION
## Summary
- add optional debug log window for troubleshooting
- log key actions when applying themes, styling entrances/exits, and placing scenery
- document new debug log feature

## Testing
- `node --check ride-theme-director.js`
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Ride-Theme-Director-OpenRCT2/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b8c398b218832dada586100a7ded6d